### PR TITLE
【Fixed】アソシエーションを利用したグループ機能の実装

### DIFF
--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -8,9 +8,7 @@ class GroupingsController < ApplicationController
     user = User.find_by(email: grouping_params) 
     if user
       group.groupings.create(user_id: user.id)
-      redirect_to group_path(group.id)
-    else
-      redirect_to group_path(group.id)
+      redirect_to group_path(group.id), notice: t('notice.member_registration_completed', email: grouping_params)
     end
   end
   

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -13,6 +13,9 @@ class GroupingsController < ApplicationController
   end
   
   def destroy
+    grouping = Grouping.find(params[:id])
+    grouping.destroy
+    redirect_to group_path(params[:group_id]), notice: t('notice.delete_member', email: grouping.user.email)
   end
   
   private

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -1,0 +1,47 @@
+class GroupingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    email_exist? and return
+    user_exist? and return
+    group = find_group(params[:group_id])
+    user = User.find_by(email: grouping_params) 
+    if user
+      group.groupings.create(user_id: user.id)
+      redirect_to group_path(group.id)
+    else
+      redirect_to group_path(group.id)
+    end
+  end
+  
+  def destroy
+  end
+  
+  private
+  
+  def grouping_params
+    params[:email]
+  end
+  
+  # すでにメンバー登録されている場合はグループ詳細画面に遷移する
+  def email_exist?
+    group = find_group(params[:group_id])
+    redirect_to group_path(group.id), notice: t('notice.registered_as_a_member', email: grouping_params) if group.members.exists?(email: grouping_params)
+  end
+  
+  # ユーザとして存在しない場合はグループ詳細画面に遷移する
+  # リファクタリング（モデルに持っていく）
+  def user_exist?
+    group = find_group(params[:group_id])
+    if !grouping_params.present?
+      redirect_to group_path(group.id), notice: t('notice.email_blank')
+    elsif !User.exists?(email: grouping_params)
+      redirect_to group_path(group.id), notice: t('notice.no_email_create_an_account', email: grouping_params)
+    end
+  end
+
+  # Group.find(params[:group_id])の共通化
+  def find_group(_group_id)
+    Group.find(params[:group_id])
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,7 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: %i[ show edit update destroy ]
   before_action :authenticate_user!
+
   def index
     @groups = Group.select(:id, :name, :explanation)
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   has_many :groupings, dependent: :destroy
-  has_many :group_users, through: :groupings
+  has_many :members, through: :groupings, source: :user
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,5 @@
 class Group < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
+  has_many :groupings, dependent: :destroy
+  has_many :group_users, through: :groupings
 end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -1,0 +1,4 @@
+class Grouping < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :groupings, dependent: :destroy
-  has_many :user_groups, through: :groupings
+  has_many :groups, through: :groupings
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,6 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :groupings, dependent: :destroy
+  has_many :user_groups, through: :groupings
 end

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -13,7 +13,7 @@
       <td><%= group.explanation %></td>
       <td><%= link_to t('.group_information_details'), group_path(group) %></td>
       <td><%= link_to t('.group_information_editing'), edit_group_path(group) %></td>
-      <td><%= link_to t('.group_deletion'), group_path(group), method: :delete, data: { confirm: t('.do_you_really_want_to_delete_this_group?') } %></td>
+      <td><%= link_to t('.group_deletion'), group_path(group), method: :delete, data: { confirm: t('.really_deleted?') } %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -16,10 +16,10 @@
     <th><%= t '.member_name' %></th>
     <th><%= t '.member_email' %></th>
   </tr>
-  <% @group.members.each do |member| %>
-    <td><%= member.name %></td>
-    <td><%= member.email %></td>
-    <td><%= link_to t('.delete_member'), group_grouping_path(@group, member.id), method: :delete, data: { confirm: t('groups.index.really_deleted?') } %></td>
+  <% @group.groupings.each do |grouping| %>
+    <td><%= grouping.user.name %></td>
+    <td><%= grouping.user.email %></td>
+    <td><%= link_to t('.delete_member'), group_grouping_path(@group, grouping), method: :delete, data: { confirm: t('groups.index.really_deleted?') } %></td>
   <% end %>
 </table>
 

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -3,4 +3,10 @@
 <p><%= t 'groups.index.group_name' %>: <%= @group.name %></p>
 <p><%= t 'groups.index.explanation' %>: <%= @group.explanation %></p>
 
+<%= t '.group_member_invitation' %>
+<%= form_with model: :grouping, scope: :post, url: group_groupings_path(@group.id), local: true do |form| %>
+  <%= text_field_tag :email, '' %>
+  <button type="submit"><%= t '.member_invitation' %></button>
+<% end %>
+
 <%= link_to t('groups.index.group_information_editing'), edit_group_path(@group) %> | <%= link_to t('groups.index.list_of_affiliated_groups'), groups_path %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -9,4 +9,19 @@
   <button type="submit"><%= t '.member_invitation' %></button>
 <% end %>
 
+<%= t '.group_members' %>
+
+<table>
+  <tr>
+    <th><%= t '.member_name' %></th>
+    <th><%= t '.member_email' %></th>
+  </tr>
+  <% @group.members.each do |member| %>
+    <td><%= member.name %></td>
+    <td><%= member.email %></td>
+    <td><%= link_to t('.delete_member'), group_grouping_path(@group, member.id), method: :delete, data: { confirm: t('groups.index.really_deleted?') } %></td>
+  <% end %>
+</table>
+
+<br>
 <%= link_to t('groups.index.group_information_editing'), edit_group_path(@group) %> | <%= link_to t('groups.index.list_of_affiliated_groups'), groups_path %>

--- a/config/locales/controllers/ja.yml
+++ b/config/locales/controllers/ja.yml
@@ -4,3 +4,6 @@ ja:
     edited_the_group: "%{name}グループを編集しました"
     edited_the_group: "%{name}グループを編集しました"
     deleted_the_group: "%{name}グループを削除しました"
+    registered_as_a_member: "%{email}は既にメンバー登録済みです"
+    no_email_create_an_account: "%{email}は存在しません、アカウント登録をお願いします"
+    email_blank: 'メールアドレスを入れてください'

--- a/config/locales/controllers/ja.yml
+++ b/config/locales/controllers/ja.yml
@@ -7,3 +7,4 @@ ja:
     registered_as_a_member: "%{email}は既にメンバー登録済みです"
     no_email_create_an_account: "%{email}は存在しません、アカウント登録をお願いします"
     email_blank: 'メールアドレスを入れてください'
+    member_registration_completed: '%{email}がメンバー登録できました'

--- a/config/locales/controllers/ja.yml
+++ b/config/locales/controllers/ja.yml
@@ -7,4 +7,5 @@ ja:
     registered_as_a_member: "%{email}は既にメンバー登録済みです"
     no_email_create_an_account: "%{email}は存在しません、アカウント登録をお願いします"
     email_blank: 'メールアドレスを入れてください'
-    member_registration_completed: '%{email}がメンバー登録できました'
+    member_registration_completed: "%{email}がメンバー登録できました"
+    delete_member: "%{email}をメンバーから削除しました"

--- a/config/locales/views /groups/ja.yml
+++ b/config/locales/views /groups/ja.yml
@@ -8,4 +8,7 @@ ja:
       group_information_details: 'グループ情報詳細'
       group_information_editing: 'グループ情報編集'
       group_deletion: 'グループ削除'
-      do_you_really_want_to_delete_this_group?: '本当にこのグループを削除しますか？'
+      really_deleted?: '本当にこのグループを削除しますか？'
+    show:
+      member_invitation: '招待'
+      group_member_invitation: 'グループメンバー招待'

--- a/config/locales/views /groups/ja.yml
+++ b/config/locales/views /groups/ja.yml
@@ -8,7 +8,11 @@ ja:
       group_information_details: 'グループ情報詳細'
       group_information_editing: 'グループ情報編集'
       group_deletion: 'グループ削除'
-      really_deleted?: '本当にこのグループを削除しますか？'
+      really_deleted?: '本当に削除しますか？'
     show:
       member_invitation: '招待'
       group_member_invitation: 'グループメンバー招待'
+      group_members: 'グループメンバー'
+      member_name: '名前'
+      member_email: 'メールアドレス'
+      delete_member: 'メンバー削除'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,12 @@
 Rails.application.routes.draw do
+  root to: 'tops#index'
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   devise_for :users
-  root to: 'tops#index'
-  resources :groups
+  
+  resources :groups do
+    resources :groupings, only: %w(create destroy)
+  end
+
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end

--- a/db/migrate/20220130024703_create_groupings.rb
+++ b/db/migrate/20220130024703_create_groupings.rb
@@ -1,0 +1,11 @@
+class CreateGroupings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :groupings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :group, null: false, foreign_key: true
+      t.boolean :group_administrator, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220213014645_add_index_to_groupings.rb
+++ b/db/migrate/20220213014645_add_index_to_groupings.rb
@@ -1,0 +1,5 @@
+class AddIndexToGroupings < ActiveRecord::Migration[6.0]
+  def change
+    add_index :groupings, [:user_id, :group_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_30_024703) do
+ActiveRecord::Schema.define(version: 2022_02_13_014645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2022_01_30_024703) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["group_id"], name: "index_groupings_on_group_id"
+    t.index ["user_id", "group_id"], name: "index_groupings_on_user_id_and_group_id", unique: true
     t.index ["user_id"], name: "index_groupings_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_26_224244) do
+ActiveRecord::Schema.define(version: 2022_01_30_024703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "groupings", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
+    t.boolean "group_administrator", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_groupings_on_group_id"
+    t.index ["user_id"], name: "index_groupings_on_user_id"
+  end
 
   create_table "groups", force: :cascade do |t|
     t.string "name", null: false
@@ -41,4 +51,6 @@ ActiveRecord::Schema.define(version: 2022_01_26_224244) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "groupings", "groups"
+  add_foreign_key "groupings", "users"
 end

--- a/spec/factories/groupings.rb
+++ b/spec/factories/groupings.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :grouping do
+    user { nil }
+    group { nil }
+    group_administrator { false }
+  end
+end

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Grouping, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Close #23 

## アソシエーションを利用したグループ機能の実装
group_function_implementation_using_association-issues#23

### usersとgroupsをgroupingsを中間テーブルとして多対多で繋ぐ
- [x] `rails g model grouping user:references group:references group_administrator:boolean`を実行する
- [x] テーブル定義書の`group_administrators`を`group_administrator`に修正（ER図の`group_administrator`に揃える）
- [x] `rails g controller groupings`を実行する

### グループ詳細画面の実装
- [x] グループ詳細画面でグループメンバーの招待ができるようにする
- [x] groupingsコントローラーでユーザー登録済みかチェックし、登録済みであればメンバー登録ができる。そうでなければ、アカウント登録を促す。登録済みであれば、その旨を表示する。
- [x] メンバーの表示ができるようにする。
- [x] グループメンバーの削除ができるようにする。

### groupings_controller.rbの実装
- [x] createアクションの実装
- [x] destroyアクションの実装

### Groupingモデルの実装
- [x] Groupingモデルで同じユーザーが、同じグループに登録されないようユニーク制約を実装する。

### その他変更
- [x] 国際化コードの英文の変更

### 参考サイト
https://railsguides.jp/form_helpers.html

以上を行いました。