### PR TITLE
【Fixed】ログイン・アカウント作成時に遷移する先をgroup一覧画面に変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  def after_sign_in_path_for(resource)
+    groups_path
+  end
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -25,6 +25,7 @@ class GroupingsController < ApplicationController
   end
   
   # すでにメンバー登録されている場合はグループ詳細画面に遷移する
+  # リファクタリング（モデルに持っていく）
   def email_exist?
     group = find_group(params[:group_id])
     redirect_to group_path(group.id), notice: t('notice.registered_as_a_member', email: grouping_params) if group.members.exists?(email: grouping_params)


### PR DESCRIPTION
Close #25 

## ログイン・アカウント作成時に遷移する先をgroup一覧画面に変更
first_to_the_group_list-issues#25

- [x] ログイン・アカウント作成時にグループ一覧画面に遷移させる

#### 参考サイト
https://nishinatoshiharu.com/change-devise-redirect/

以上を行いました。