### PR TITLE
【Fixed】メンバーは所属しているグループのみ操作・表示ができるように実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  include GroupingsHelper
 
   def after_sign_in_path_for(resource)
     groups_path

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -1,18 +1,17 @@
 class GroupingsController < ApplicationController
   before_action :set_grouping, only: %i[ update destroy ]
   before_action :set_groupings, only: %i[ update destroy ]
-  before_action :set_group, only: %i[ update destroy ]
+  before_action :set_group
   before_action :authenticate_user!
-  before_action :create_update_destroy_group_admin?
+  before_action :group_admin_authority?, only: %i[ update destroy ] # createアクションには実装不要か？
 
   def create
     email_exist? and return
     user_exist? and return
-    group = find_group(params_group_id)
-    user = User.find_by(email: params_email) 
+    user = User.find_by(email: params[:email]) 
     if user
-      group.groupings.create(user_id: user.id)
-      redirect_to group_path(group.id), notice: t('notice.member_registration_completed', email: params_email)
+      @group.groupings.create(user_id: user.id)
+      redirect_to group_path(@group.id), notice: t('notice.member_registration_completed', email: params[:email])
     else
       render template: "groups/show"
     end
@@ -28,7 +27,7 @@ class GroupingsController < ApplicationController
 
   def destroy
     if @grouping.destroy
-      redirect_to group_path(params_group_id), notice: t('notice.delete_member', email: @grouping.user.email)
+      redirect_to group_path(params[:group_id]), notice: t('notice.delete_member', email: @grouping.user.email)
     else
       render template: "groups/show"
     end
@@ -37,43 +36,30 @@ class GroupingsController < ApplicationController
   
   private
   
-  def params_email
-    params[:email]
-  end
-
-  def params_group_id
-    params[:group_id]
+  def email_exist? # すでにメンバー登録されている場合はグループ詳細画面に遷移する,リファクタリング（モデルに持っていく）
+    set_group
+    redirect_to group_path(@group.id), notice: t('notice.registered_as_a_member', email: params[:email]) if @group.members.exists?(email: params[:email])
   end
   
-  # すでにメンバー登録されている場合はグループ詳細画面に遷移する
-  # リファクタリング（モデルに持っていく）
-  def email_exist?
-    group = find_group(params_group_id)
-    redirect_to group_path(group.id), notice: t('notice.registered_as_a_member', email: params_email) if group.members.exists?(email: params_email)
-  end
-  
-  # ユーザとして存在しない場合はグループ詳細画面に遷移する
-  # リファクタリング（モデルに持っていく）
-  def user_exist?
-    group = find_group(params_group_id)
-    if !params_email.present?
-      redirect_to group_path(group.id), notice: t('notice.email_blank')
-    elsif !User.exists?(email: params_email)
-      redirect_to group_path(group.id), notice: t('notice.no_email_create_an_account', email: params_email)
+  def user_exist? # ユーザとして存在しない場合はグループ詳細画面に遷移する,リファクタリング（モデルに持っていく）
+    set_group
+    if !params[:email].present?
+      redirect_to group_path(@group.id), notice: t('notice.email_blank')
+    elsif !User.exists?(email: params[:email])
+      redirect_to group_path(@group.id), notice: t('notice.no_email_create_an_account', email: params[:email])
     end
   end
 
-  def grouping_admin_grant_or_release
+  def grouping_admin_grant_or_release # 管理者権限の付与・解除時に表示されるtoticeの条件分岐
     if @grouping.admin
-      redirect_to group_path(params_group_id), notice: t('notice.grant_admin_privilege', email: @grouping.user.email)
+      redirect_to group_path(params[:group_id]), notice: t('notice.grant_admin_privilege', email: @grouping.user.email)
     else
-      redirect_to group_path(params_group_id), notice: t('notice.release_admin_privilege', email: @grouping.user.email)
+      redirect_to group_path(params[:group_id]), notice: t('notice.release_admin_privilege', email: @grouping.user.email)
     end
   end
 
-  # Group.find(params_group_id)の共通化
-  def find_group(_group_id)
-    Group.find(params_group_id)
+  def group_admin_authority? # グループ管理者ではない場合、グループ詳細画面にリダイレクトする
+    redirect_to group_path(params[:group_id]) unless group_admin?
   end
 
   def set_grouping
@@ -81,15 +67,11 @@ class GroupingsController < ApplicationController
   end
 
   def set_group
-    @group = find_group(params_group_id)
+    @group = Group.find(params[:group_id])
   end
 
-  def set_groupings
-    group = Group.find(params_group_id)
+  def set_groupings # グループに所属しているメンバー情報を取得している
+    group = Group.find(params[:group_id])
     @groupings = group.groupings.includes(:user)
-  end
-
-  def create_update_destroy_group_admin?
-    redirect_to group_path(params_group_id), notice: t('notice.unauthorized') unless group_admin?
   end
 end

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -1,9 +1,9 @@
 class GroupingsController < ApplicationController
-  before_action :set_grouping
+  before_action :set_grouping, only: %i[ update destroy ]
   before_action :set_groupings, only: %i[ update destroy ]
   before_action :set_group, only: %i[ update destroy ]
   before_action :authenticate_user!
-  before_action :grouping_admin?
+  before_action :create_update_destroy_group_admin?
 
   def create
     email_exist? and return
@@ -89,7 +89,7 @@ class GroupingsController < ApplicationController
     @groupings = group.groupings.includes(:user)
   end
 
-  def grouping_admin?
-    render template: "groups/show" unless @grouping.admin == true && current_user == @grouping.user
+  def create_update_destroy_group_admin?
+    redirect_to group_path(params_group_id), notice: t('notice.unauthorized') unless group_admin?
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -41,11 +41,11 @@ class GroupsController < ApplicationController
   end
 
   private
-    def group_params
-      params.require(:group).permit(:name, :explanation)
-    end
+  def group_params
+    params.require(:group).permit(:name, :explanation)
+  end
 
-    def set_group
-      @group = Group.find(params[:id])
-    end
+  def set_group
+    @group = Group.find(params[:id])
+  end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,9 +1,10 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: %i[ show edit update destroy ]
   before_action :authenticate_user!
+  before_action :login_user_group?, only: %i[ show edit update destroy ]
 
-  def index
-    @groups = Group.select(:id, :name, :explanation)
+  def index # ログインユーザーのみのグループ一覧を表示する
+    @groups = current_user.groups
   end
   
   def show
@@ -47,5 +48,9 @@ class GroupsController < ApplicationController
 
   def set_group
     @group = Group.find(params[:id])
+  end
+
+  def login_user_group? # 所属していないグループにアクセスすると、グループ一覧にリダイレクトされる
+    redirect_to groups_path unless current_user.groups.ids.include?(params[:id].to_i)
   end
 end

--- a/app/helpers/groupings_helper.rb
+++ b/app/helpers/groupings_helper.rb
@@ -1,7 +1,8 @@
 module GroupingsHelper
   def group_admin?
     @groupings.try!(:each) do |grouping|
-      return unless grouping.admin == true && current_user == grouping.user
+      return true if grouping.admin == true && current_user == grouping.user
     end
+    false
   end
 end

--- a/app/helpers/groupings_helper.rb
+++ b/app/helpers/groupings_helper.rb
@@ -1,6 +1,6 @@
 module GroupingsHelper
-  def group_admin?
-    @groupings.try!(:each) do |grouping|
+  def group_admin? # ログイン中のユーザーがグループ管理者か判別を行なっている
+    @groupings.each do |grouping|
       return true if grouping.admin == true && current_user == grouping.user
     end
     false

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -34,7 +34,7 @@
     <tr>
     <td><%= grouping.user.name %></td>
     <td><%= grouping.user.email %></td>
-    <% if grouping.admin == true && current_user == grouping.user %>
+    <% if group_admin? %>
       <% if grouping.admin %>
         <td><%= link_to t('.release_admin_privilege'), group_grouping_path(@group, grouping, admin: false), method: :put %></td>
       <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
     
     <% if user_signed_in? %>
       <li><%= link_to t('view.logout'), destroy_user_session_path, method: :delete %></li>
+      <li><%= current_user.name %></li>
     <% else %>
       <li><%= link_to t('view.login'), new_user_session_path %></li>
       <li><%= link_to t('view.account_registration'), new_user_registration_path %></li>

--- a/config/locales/controllers/ja.yml
+++ b/config/locales/controllers/ja.yml
@@ -11,3 +11,4 @@ ja:
     delete_member: "%{email}をメンバーから削除しました"
     grant_admin_privilege: "%{email}に管理者権限を付与しました"
     release_admin_privilege: "%{email}の管理者権限を解除しました"
+    unauthorized: "権限がありません"


### PR DESCRIPTION
Close #30 

## メンバーは所属しているグループのみ操作・表示ができるように実装

members_are_only_affiliated_groups-issues#30

- [x] メンバーが所属しているグループのみ操作・表示ができるよう実装する

### その他
- [x] 管理者の制限機能の不具合を解消
参考URL　[Ruby eachとif文が入れ子になった処理を終える](https://teratail.com/questions/27339)
- [x] ログイン者がわかるようにヘッダーに表示する
- [x] groupingsのcontrollerをリファクタリング