### PR TITLE
【Fixed】各ページのリンクを整える

### DIFF
--- a/app/views/blogs/confirm.html.erb
+++ b/app/views/blogs/confirm.html.erb
@@ -1,4 +1,4 @@
-<h3><%= t '.is_this_content_okay?' %></h3>
+<h3><%= @group.name%><%= t '.is_the_blog_content_okay?' %></h3>
 
 <%= form_with(model:[@group, @blog], local: true) do |form| %>
   <%= form.hidden_field :title %>

--- a/app/views/blogs/edit.html.erb
+++ b/app/views/blogs/edit.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t 'blogs.index.blog_editing' %></h2>
+<h2><%= @group.name %><%= t 'blogs.index.blog_editing' %></h2>
 
 <%= render 'form' %>
 

--- a/app/views/blogs/index.html.erb
+++ b/app/views/blogs/index.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t '.blog_index' %></h2>
+<h2><%= @group.name %><%= t '.blog_index' %></h2>
 
 <%= link_to t('.new_blog_contribution'), new_group_blog_path(@group) %>
 

--- a/app/views/blogs/new.html.erb
+++ b/app/views/blogs/new.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t 'blogs.index.new_blog_contribution' %></h2>
+<h2><%= @group.name %><%= t 'blogs.index.new_blog_contribution' %></h2>
 
 <%= render 'form' %>
 

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t 'blogs.index.blog_detail' %></h2>
+<h2><%= @group.name %><%= t 'blogs.index.blog_detail' %></h2>
 
 <p><%= t 'blogs.index.new_contributor' %>: <%= @blog.new_contributor.name %></p>
 <% if @blog.last_updater_id.present? %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -14,6 +14,7 @@
       <td><%= link_to t('.group_information_details'), group_path(group) %></td>
       <td><%= link_to t('.group_information_editing'), edit_group_path(group) %></td>
       <td><%= link_to t('.group_deletion'), group_path(group), method: :delete, data: { confirm: t('.really_deleted?') } %></td>
+      <td><%= link_to t('.group_blog_index'), group_blogs_path(group) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -11,6 +11,11 @@
   </div>
 <% end %>
 
+<ul>
+  <li><%= link_to t('.new_group_blog_contribution'), new_group_blog_path(@group) %></li>
+  <li><%= link_to t('groups.index.group_blog_index'), group_blogs_path(@group) %></li>
+</ul>
+
 <p><%= t 'groups.index.group_name' %>: <%= @group.name %></p>
 <p><%= t 'groups.index.explanation' %>: <%= @group.explanation %></p>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,17 +12,31 @@
 
   <body>
     <header>
-    <% flash.each do |key, value| %>
-      <%= content_tag(:div, value, class: "#{key}") %>
-    <% end %>
-    
-    <% if user_signed_in? %>
-      <li><%= link_to t('view.logout'), destroy_user_session_path, method: :delete %></li>
-      <li><%= current_user.name %></li>
-    <% else %>
-      <li><%= link_to t('view.login'), new_user_session_path %></li>
-      <li><%= link_to t('view.account_registration'), new_user_registration_path %></li>
-    <% end %>
+      <% flash.each do |key, value| %>
+        <%= content_tag(:div, value, class: "#{key}") %>
+      <% end %>
+
+      <ul>
+        <li><%= link_to t('view.re_time_line'), root_path %></li>
+      </ul>
+      <% if user_signed_in? %>
+        <ul>
+          <% if controller_name == "blogs" %>
+            <li><%= link_to t('blogs.index.new_blog_contribution'), new_group_blog_path(@group) %></li>
+            <li><%= link_to t('blogs.index.blog_index'), group_blogs_path(@group) %></li>
+          <% elsif controller_name == "groups" %>
+            <li><%= link_to t('groups.index.group_new_registration'), new_group_path %></li>
+          <% end %>
+          <li><%= link_to t('groups.index.list_of_affiliated_groups'), groups_path %></li>
+          <li><%= current_user.name %></li>
+          <li><%= link_to t('view.logout'), destroy_user_session_path, method: :delete %></li>
+        </ul>
+      <% else %>
+        <ul>
+          <li><%= link_to t('view.login'), new_user_session_path %></li>
+          <li><%= link_to t('view.account_registration'), new_user_registration_path %></li>
+        </ul>
+      <% end %>
     </header>
     <%= yield %>
   </body>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -21,5 +21,11 @@
         <li>友達と使う</li>
       </ul>
     </div>
+    <div>
+      <ul>
+        <li><%= link_to t('view.login'), new_user_session_path %></li>
+        <li><%= link_to t('view.account_registration'), new_user_registration_path %></li>
+      </ul>
+    </div>
   </article>
 </div>

--- a/config/locales/defaults/ja.yml
+++ b/config/locales/defaults/ja.yml
@@ -211,3 +211,4 @@ ja:
     logout: 'ログアウト'
     login: 'ログイン'
     account_registration: 'アカウント登録'
+    re_time_line: 'Re: Timeline'

--- a/config/locales/views /blogs/ja.yml
+++ b/config/locales/views /blogs/ja.yml
@@ -12,6 +12,6 @@ ja:
       blog_deletion: 'ブログ削除'
       really_deleted?: '本当に削除しますか？'
     confirm:
-      is_this_content_okay?: '以下の内容で投稿して良いでしょうか？'
+      is_the_blog_content_okay?: 'ブログ以下の内容で投稿して良いでしょうか？'
       contribute: '投稿する'
       back: '戻る'

--- a/config/locales/views /groups/ja.yml
+++ b/config/locales/views /groups/ja.yml
@@ -8,6 +8,7 @@ ja:
       group_information_details: 'グループ情報詳細'
       group_information_editing: 'グループ情報編集'
       group_deletion: 'グループ削除'
+      group_blog_index: 'グループブログ一覧'
       really_deleted?: '本当に削除しますか？'
     show:
       member_invitation: '招待'
@@ -19,3 +20,4 @@ ja:
       group_admin: 'グループ管理者'
       grant_admin_privilege: '管理者権限を付与'
       release_admin_privilege: '管理権限を解除'
+      new_group_blog_contribution: 'グループブログ新規投稿'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,4 @@
 Rails.application.routes.draw do
-  get 'blogs/index'
-  get 'blogs/show'
-  get 'blogs/new'
-  get 'blogs/edit'
   root to: 'tops#index'
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   devise_for :users


### PR DESCRIPTION
Close #41 

# 各ページのリンクを整える
page_link_adjustment-issues#41

## headerのリンクを調整
- [x] ログイン時のグループ設定時のヘッダーを作成
- [x] ログイン時のグループのブログ作成時のヘッダーを作成
- [x] トップページへのリンクを作成

## TOPページのリンクを調整
- [x] ログイン・アカウント登録のリンクを作成

## グループ一覧ページの調整
- [x] グループのブログへのリンクを作成

## グループ詳細ページの調整
- [x] グループブログ新規投稿・一覧へのリンクを作成

## その他
- [x] グループのブログにどこのグループのブログを表示しているか分かるようにする

## 参考サイト
[【Rails】ページごとに表示を変える](https://qiita.com/ohnitakahiro/items/7137007885a783a94be1)
[指定したURLが現在表示されているかチェック](https://railsdoc.com/page/current_page_q)
[[Rails 表示中のページを判定する方法　複数のcurrent_page?を判定する方法](https://shonoooo.hatenablog.com/entry/2017/10/31/232302)
[[Rails]コントローラ名、アクション名、URLなどを取得する](https://qiita.com/yosaprog/items/ab24ff88aa50c466f72b)
[[Rails] Controllerで表示してるページのパスを判定したい](https://www.cotegg.com/blog/?p=2059)

以上が完了しました。