### PR TITLE
【Fixed】グループ名は同じ名前が使われないよう実装

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
-  validates :name, presence: true, length: { maximum: 255 }
+  validates :name, presence: true, length: { maximum: 255 }, uniqueness: true
   has_many :groupings, dependent: :destroy
   has_many :members, through: :groupings, source: :user
   has_many :blogs, dependent: :destroy

--- a/db/migrate/20220321150615_add_index_to_groups_name.rb
+++ b/db/migrate/20220321150615_add_index_to_groups_name.rb
@@ -1,0 +1,5 @@
+class AddIndexToGroupsName < ActiveRecord::Migration[6.0]
+  def change
+    add_index :groups, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_19_023457) do
+ActiveRecord::Schema.define(version: 2022_03_21_150615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2022_03_19_023457) do
     t.text "explanation"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_groups_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Close #45 

## グループ名は同じ名前が使われないよう実装

group_name_unique-issues#45

- [x] Groupモデルのグループ名にユニーク制約を実装する
- [x] groupsテーブルのグループ名にユニーク制約を実装する

### 参考サイト
[一意性を保つバリデーションの実装](https://qiita.com/beanzou/items/dee423185cd4856b82fe)
[Railsガイド uniqueness](https://railsguides.jp/active_record_validations.html#uniqueness)
[Pikawaka uniqueness](https://pikawaka.com/rails/validation#uniqueness)

以上が完了しました。