### PR TITLE
【Fixed】ブログ新規投稿者とグループ管理者のみに編集・削除の権限を持たせるよう実装

### DIFF
--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -1,13 +1,16 @@
 class BlogsController < ApplicationController
   before_action :login_user_group_blog?
+  before_action :blogs_new_contributor_or_group_admin?, only: %i[ edit update destroy ]
   before_action :set_group_id
   before_action :set_blog, only: %i[ show edit update destroy ]
   
   def index
     @blogs = @group.blogs.includes(:new_contributor, :last_updater)
+    @groupings = @group.groupings
   end
 
   def show
+    @groupings = @group.groupings
   end
 
   def new
@@ -63,5 +66,13 @@ class BlogsController < ApplicationController
   # 所属していないグループのブログにアクセスすると、グループ一覧にリダイレクトされる
   def login_user_group_blog?
     redirect_to groups_path unless current_user.groups.ids.include?(params[:group_id].to_i)
+  end
+
+  # ブログの新規投稿者かグループの管理者か判定をしている
+  def blogs_new_contributor_or_group_admin?
+    set_group_id
+    set_blog
+    @groupings = @group.groupings
+    redirect_to group_blogs_path(@group) unless current_user.id == @blog.new_contributor_id || group_admin?
   end
 end

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -3,7 +3,7 @@ class GroupingsController < ApplicationController
   before_action :set_groupings, only: %i[ update destroy ]
   before_action :set_group
   before_action :authenticate_user!
-  before_action :group_admin_authority?, only: %i[ update destroy ] # createアクションには実装不要か？
+  before_action :group_admin_members?, only: %i[ update destroy ] # createアクションには実装不要か？、あった方がいい！？
 
   def create
     email_exist? and return
@@ -58,7 +58,7 @@ class GroupingsController < ApplicationController
     end
   end
 
-  def group_admin_authority? # グループ管理者ではない場合、グループ詳細画面にリダイレクトする
+  def group_admin_members? # グループ管理者ではない場合、グループ詳細画面にリダイレクトする
     redirect_to group_path(params[:group_id]) unless group_admin?
   end
 

--- a/app/views/blogs/index.html.erb
+++ b/app/views/blogs/index.html.erb
@@ -20,8 +20,10 @@
         <td><%= "" %></td>
       <% end %>
       <td><%= link_to t('.blog_detail'),  group_blog_path(@group, blog) %></td>
-      <td><%= link_to t('.blog_editing'),  edit_group_blog_path(@group, blog) %></td>
-      <td><%= link_to t('.blog_deletion'),  group_blog_path(@group, blog), method: :delete, data: { confirm: t('groups.index.really_deleted?') } %></td>
+      <% if current_user.id == blog.new_contributor_id || group_admin? %>
+        <td><%= link_to t('.blog_editing'),  edit_group_blog_path(@group, blog) %></td>
+        <td><%= link_to t('.blog_deletion'),  group_blog_path(@group, blog), method: :delete, data: { confirm: t('groups.index.really_deleted?') } %></td>
+      <% end %>
     </tr>
   <% end %>
 </table>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -7,4 +7,7 @@
 <p><%= t 'blogs.index.title' %>: <%= @blog.title %></p>
 <p><%= t 'blogs.index.content' %>: <%= @blog.content %></p>
 
-<%= link_to t('blogs.index.blog_editing'), edit_group_blog_path(@group) %> | <%= link_to t('blogs.index.blog_index'), group_blogs_path(@group) %>
+<% if current_user.id == @blog.new_contributor_id || group_admin? %>
+  <%= link_to t('blogs.index.blog_editing'), edit_group_blog_path(@group) %> | 
+<% end %>
+<%= link_to t('blogs.index.blog_index'), group_blogs_path(@group) %>


### PR DESCRIPTION
Close #44 

## ブログ新規投稿者とグループ管理者にブログの編集・削除の権限が持てるよう実装

blog_edit_delete_authority-issues#44

- [x] ブログの新規投稿者に編集・削除権限を持たせる
- [x] グループの管理者にブログの編集・削除権限を持たせる
- [x] viewとcontrollerどちらにも実装をする
上記以外は、ブログの編集・削除権限を持たせない。

以上が完了しました。