### PR TITLE
【Fixed】controllersの共通化処理

### DIFF
--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -1,4 +1,5 @@
 class BlogsController < ApplicationController
+  include Common
   before_action :login_user_group_blog?
   before_action :blogs_new_contributor_or_group_admin?, only: %i[ edit update destroy ]
   before_action :set_group_id
@@ -53,10 +54,6 @@ class BlogsController < ApplicationController
 
   def blog_params
     params.require(:blog).permit(:title, :content)
-  end
-
-  def set_group_id
-    @group = Group.find(params[:group_id])
   end
 
   def set_blog

--- a/app/controllers/concerns/common.rb
+++ b/app/controllers/concerns/common.rb
@@ -1,0 +1,7 @@
+module Common
+  extend ActiveSupport::Concern
+
+  def set_group_id
+    @group = Group.find(params[:group_id])
+  end
+end

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -1,7 +1,8 @@
 class GroupingsController < ApplicationController
+  include Common
   before_action :set_grouping, only: %i[ update destroy ]
   before_action :set_groupings, only: %i[ update destroy ]
-  before_action :set_group
+  before_action :set_group_id
   before_action :authenticate_user!
   before_action :group_admin_members?, only: %i[ update destroy ] # createアクションには実装不要か？、あった方がいい！？
 
@@ -37,12 +38,12 @@ class GroupingsController < ApplicationController
   private
   
   def email_exist? # すでにメンバー登録されている場合はグループ詳細画面に遷移する,リファクタリング（モデルに持っていく）
-    set_group
+    set_group_id
     redirect_to group_path(@group.id), notice: t('notice.registered_as_a_member', email: params[:email]) if @group.members.exists?(email: params[:email])
   end
   
   def user_exist? # ユーザとして存在しない場合はグループ詳細画面に遷移する,リファクタリング（モデルに持っていく）
-    set_group
+    set_group_id
     if !params[:email].present?
       redirect_to group_path(@group.id), notice: t('notice.email_blank')
     elsif !User.exists?(email: params[:email])
@@ -66,12 +67,8 @@ class GroupingsController < ApplicationController
     @grouping = Grouping.find(params[:id])
   end
 
-  def set_group
-    @group = Group.find(params[:group_id])
-  end
-
   def set_groupings # グループに所属しているメンバー情報を取得している
-    group = Group.find(params[:group_id])
-    @groupings = group.groupings.includes(:user)
+    set_group_id
+    @groupings = @group.groupings.includes(:user)
   end
 end


### PR DESCRIPTION
## controllersの共通化処理

controllers_common-issues#49

- [x] groupings_controllerの共通化処理
- [x] blogs_controllerの共通化処理

### 参考サイト
[Rails 共通部分を切り出す (View, Controller, Model) メモ](https://qiita.com/shizuma/items/ae6ecb85615f74444693)
[Ruby on RailsでConcernsを利用してControllerの処理を共通化する](https://programming-beginner-zeroichi.jp/articles/142)
[我々はConcernsとどう向き合うか](https://blog.willnet.in/entry/2019/12/02/093000)
[ビジネスロジック](https://wa3.i-3-i.info/word13666.html)
[「ビジネスロジック」とは何か、どう実装するのか](https://qiita.com/os1ma/items/25725edfe3c2af93d735)
[[Rails] ActiveSupport::Concern の存在理由](https://qiita.com/castaneai/items/6dc121ce6ff100614f42)
[ActiveSupport::Concern](https://api.rubyonrails.org/classes/ActiveSupport/Concern.html)

以上が完了しました。