### PR TITLE
【Fixed】ユーザーを削除した際にblog新規投稿者と最終更新者が「nil:NilClass」にならないように修正

### DIFF
--- a/app/views/blogs/index.html.erb
+++ b/app/views/blogs/index.html.erb
@@ -13,14 +13,18 @@
     <tr>
       <td><%= blog.title %></td>
       <td><%= blog.content %></td>
-      <td><%= blog.new_contributor.name %></td>
-      <% if blog.last_updater_id.present? %>
+      <% if blog.new_contributor.present? %>
+        <td><%= blog.new_contributor.name %></td>
+      <% else %>
+        <td><%= t '.absence' %></td>
+      <% end %>
+      <% if blog.last_updater.present? %>
         <td><%= blog.last_updater.name %></td>
       <% else %>
-        <td><%= "" %></td>
+        <td><%= t '.absence' %></td>
       <% end %>
       <td><%= link_to t('.blog_detail'),  group_blog_path(@group, blog) %></td>
-      <% if current_user.id == blog.new_contributor_id || @group_admin_or_general %>
+      <% if current_user.id == blog.new_contributor || @group_admin_or_general %>
         <td><%= link_to t('.blog_editing'),  edit_group_blog_path(@group, blog) %></td>
         <td><%= link_to t('.blog_deletion'),  group_blog_path(@group, blog), method: :delete, data: { confirm: t('groups.index.really_deleted?') } %></td>
       <% end %>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,9 +1,22 @@
 <h2><%= @group.name %><%= t 'blogs.index.blog_detail' %></h2>
 
-<p><%= t 'blogs.index.new_contributor' %>: <%= @blog.new_contributor.name %></p>
-<% if @blog.last_updater_id.present? %>
-  <p><%= t 'blogs.index.last_updater' %>: <%= @blog.last_updater.name %>
-<% end %>
+
+<p>
+  <%= t 'blogs.index.new_contributor' %>: 
+  <% if @blog.last_updater.present? %>
+    <%= @blog.new_contributor.name %>
+  <% else %>
+    <%= t 'blogs.index.absence' %>
+  <% end %>
+</p>
+<p>
+  <%= t 'blogs.index.last_updater' %>:
+  <% if @blog.last_updater.present? %>
+    <%= @blog.last_updater.name %>
+  <% else %>
+    <%= t 'blogs.index..absence' %>
+  <% end %>
+</p>
 <p><%= t 'blogs.index.title' %>: <%= @blog.title %></p>
 <p><%= t 'blogs.index.content' %>: <%= @blog.content %></p>
 

--- a/config/locales/views/blogs/ja.yml
+++ b/config/locales/views/blogs/ja.yml
@@ -11,6 +11,7 @@ ja:
       blog_editing: 'ブログ編集'
       blog_deletion: 'ブログ削除'
       really_deleted?: '本当に削除しますか？'
+      absence: '−'
     confirm:
       is_the_blog_content_okay?: 'ブログ以下の内容で投稿して良いでしょうか？'
       contribute: '投稿する'


### PR DESCRIPTION
Close #56 

user_deletion_group_blog_modification-issues#56

- [x] ユーザーを削除した際に「blog.new_contributor.name」が「nil:NilClass」にならないように修正

### その他
- [x] 国際化ファイルの微調整 