### PR TITLE
【Fixed】グループ管理者のみグループ編集・削除が行えるように修正

### DIFF
--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -61,7 +61,7 @@ class BlogsController < ApplicationController
     @blog = Blog.find(params[:id])
   end
 
-  def blogs_new_contributor_or_group_admin?  # ブログの新規投稿者かグループの管理者か判定をしている
+  def blogs_new_contributor_or_group_admin?  # ブログの新規投稿者かグループの管理者でない場合はブログ一覧に返す
     redirect_to group_blogs_path(@group) unless current_user.id == @blog.new_contributor_id || group_admin?
   end
 end

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -21,6 +21,7 @@ class GroupingsController < ApplicationController
     if @grouping.update(admin: params[:admin])
       grouping_admin_grant_or_release
     else
+      update_destroy_else_render
       render template: "groups/show"
     end
   end
@@ -29,6 +30,7 @@ class GroupingsController < ApplicationController
     if @grouping.destroy
       redirect_to group_path(@group), notice: t('notice.delete_member', email: @grouping.user.email)
     else
+      update_destroy_else_render
       render template: "groups/show"
     end
   end
@@ -62,5 +64,10 @@ class GroupingsController < ApplicationController
 
   def set_grouping
     @grouping = Grouping.find(params[:id])
+  end
+
+  def update_destroy_else_render # update,destroyでelseの時にrenderで必要な情報
+    @groupings = @group.groupings.includes(:user)
+    group_admin_or_general
   end
 end

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -35,7 +35,6 @@ class GroupingsController < ApplicationController
     end
   end
 
-  
   private
   
   def email_exist? # すでにメンバー登録されている場合はグループ詳細画面に遷移する,リファクタリング（モデルに持っていく）

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,10 +2,15 @@ class GroupsController < ApplicationController
   before_action :authenticate_user!
   include Common
   before_action :set_group, only: %i[ show edit update destroy ]
+  before_action :group_admin_only, only: %i[ edit update destroy ]
   before_action :current_user_belong_to_groups?, only: %i[ show edit update destroy ]
 
-  def index # ログインユーザーのみのグループ一覧を表示する
+  def index
+    # ログインユーザーのみのグループ一覧を表示する
     @groups = current_user.groups
+
+    # ログインユーザーがグループ管理者のグループのidを抽出している
+    @groupings_admin = current_user.groupings.where(admin: true).pluck(:group_id)
   end
   
   def show
@@ -50,5 +55,9 @@ class GroupsController < ApplicationController
 
   def set_group
     @group = Group.find(params[:id])
+  end
+
+  def group_admin_only # グループ管理者以外はグループ一覧に戻る
+    redirect_to groups_path unless group_admin?
   end
 end

--- a/app/views/blogs/index.html.erb
+++ b/app/views/blogs/index.html.erb
@@ -24,7 +24,7 @@
         <td><%= t '.absence' %></td>
       <% end %>
       <td><%= link_to t('.blog_detail'),  group_blog_path(@group, blog) %></td>
-      <% if current_user.id == blog.new_contributor || @group_admin_or_general %>
+      <% if current_user.id == blog.new_contributor_id || @group_admin_or_general %>
         <td><%= link_to t('.blog_editing'),  edit_group_blog_path(@group, blog) %></td>
         <td><%= link_to t('.blog_deletion'),  group_blog_path(@group, blog), method: :delete, data: { confirm: t('groups.index.really_deleted?') } %></td>
       <% end %>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -14,7 +14,7 @@
   <% if @blog.last_updater.present? %>
     <%= @blog.last_updater.name %>
   <% else %>
-    <%= t 'blogs.index..absence' %>
+    <%= t 'blogs.index.absence' %>
   <% end %>
 </p>
 <p><%= t 'blogs.index.title' %>: <%= @blog.title %></p>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -12,8 +12,10 @@
       <td><%= group.name %></td>
       <td><%= group.explanation %></td>
       <td><%= link_to t('.group_information_details'), group_path(group) %></td>
-      <td><%= link_to t('.group_information_editing'), edit_group_path(group) %></td>
-      <td><%= link_to t('.group_deletion'), group_path(group), method: :delete, data: { confirm: t('.really_deleted?') } %></td>
+      <% if @groupings_admin.include?(group.id) %>
+        <td><%= link_to t('.group_information_editing'), edit_group_path(group) %></td>
+        <td><%= link_to t('.group_deletion'), group_path(group), method: :delete, data: { confirm: t('.really_deleted?') } %></td>
+      <% end %>
       <td><%= link_to t('.group_blog_index'), group_blogs_path(group) %></td>
     </tr>
   <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -41,9 +41,9 @@
     <td><%= grouping.user.email %></td>
     <% if @group_admin_or_general %>
       <% if grouping.admin %>
-        <td><%= link_to t('.release_admin_privilege'), group_grouping_path(@group, grouping, admin: false), method: :put %></td>
+        <td><%= link_to t('.release_admin_privilege'), group_grouping_path(@group, grouping, admin: false), method: :put, data: { confirm: t('.release_admin_privilege?') } %></td>
       <% else %>
-        <td><%= link_to t('.grant_admin_privilege'), group_grouping_path(@group, grouping, admin: true), method: :put %></td>
+        <td><%= link_to t('.grant_admin_privilege'), group_grouping_path(@group, grouping, admin: true), method: :put, data: { confirm: t('.grant_admin_privilege?') } %></td>
       <% end %>
       <td><%= link_to t('.delete_member'), group_grouping_path(@group, grouping), method: :delete, data: { confirm: t('groups.index.really_deleted?') } %></td>
     <% end %>

--- a/config/locales/views/groups/ja.yml
+++ b/config/locales/views/groups/ja.yml
@@ -19,5 +19,7 @@ ja:
       delete_member: 'メンバー削除'
       group_admin: 'グループ管理者'
       grant_admin_privilege: '管理者権限を付与'
+      grant_admin_privilege?: '管理者権限を付与しますか？'
       release_admin_privilege: '管理権限を解除'
+      release_admin_privilege?: '管理権限を解除しますか？'
       new_group_blog_contribution: 'グループブログ新規投稿'


### PR DESCRIPTION
Close #54 

## グループ管理者のみグループ編集・削除が行えるように修正

group_editing_and_deletion_for_group_admin_only-issues#54

- [x] グループ管理者のみグループ編集・削除が行えるようにする
- [x] グループ管理者が1名の時に、管理者権限を解除・削除する際に起こるエラーを修正
- [x] 権限の切り替え時に確認ダイアログを表示するように実装

### 参考サイト
[pluckメソッドが便利な件について](https://qiita.com/k-o-u/items/31e4a2f9f5d2a3c7867f)