### PR TITLE
【Fixed】blogsテーブルのevent_dateカラムのデータ型を変更

### DIFF
--- a/app/views/blogs/index.html.erb
+++ b/app/views/blogs/index.html.erb
@@ -15,7 +15,7 @@
     <% @blogs.each do |blog| %>
     <tr>
       <td><%= blog.title %></td>
-      <td><%= l blog.event_date, format: :date %></td>
+      <td><%= l blog.event_date, format: :long %></td>
       <% if blog.new_contributor.present? %>
         <td><%= blog.new_contributor.name %></td>
       <% else %>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -2,7 +2,7 @@
 
 
 <p><%= t 'blogs.index.title' %>: <%= @blog.title %></p>
-<p><%= t 'blogs.index.event_date' %>: <%= l @blog.event_date, format: :date %></p>
+<p><%= t 'blogs.index.event_date' %>: <%= l @blog.event_date, format: :long %></p>
 <p>
   <%= t 'blogs.index.new_contributor' %>: 
   <% if @blog.new_contributor.present? %>

--- a/config/locales/defaults/ja.yml
+++ b/config/locales/defaults/ja.yml
@@ -208,7 +208,6 @@ ja:
       default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
-      date: "%Y年%m月%d日"
     pm: 午後
   view:
     error_has_occurred: '件のエラーが発生しました'

--- a/db/migrate/20220402012148_change_data_event_date_to_blogs.rb
+++ b/db/migrate/20220402012148_change_data_event_date_to_blogs.rb
@@ -1,0 +1,5 @@
+class ChangeDataEventDateToBlogs < ActiveRecord::Migration[6.0]
+  def change
+    change_column :blogs, :event_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_28_042023) do
+ActiveRecord::Schema.define(version: 2022_04_02_012148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 2022_03_28_042023) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "group_id", null: false
     t.text "photo"
-    t.datetime "event_date", default: -> { "now()" }, null: false
+    t.date "event_date", default: -> { "now()" }, null: false
     t.boolean "email_notice", default: true, null: false
     t.index ["group_id"], name: "index_blogs_on_group_id"
     t.index ["last_updater_id"], name: "index_blogs_on_last_updater_id"


### PR DESCRIPTION
Close #69 

## blogsテーブルのevent_dateカラムのデータ型を変更

change_data_type_of_event_date_in_blogs_table-issues#69

- [x] `event_date`のデータ型を`detatime` → `date`に変更
- [x] マイグレーションファイル作成`rails g migration change_data_event_date_to_blogs`
- [x] それに付随したコードの修正

### 参考サイト
[【Rails】カラムのデータ型変更方法](https://qiita.com/yana_dev/items/c96594bbea3329ef0fec)
[[Rails]データベースのデータ型種類について勉強してみた！](https://qiita.com/jackie0922youhei/items/472ae8a35455475b3de8)