### PR TITLE
Mail delivery failure issues#93

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -33,6 +33,7 @@ require "capistrano/bundler"
 require "capistrano/rails/assets"
 require "capistrano/rails/migrations"
 require "capistrano3/unicorn"
+require 'whenever/capistrano'
 # require "capistrano/passenger"
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -15,7 +15,6 @@ class BlogsController < ApplicationController
     lat_log_present?
     @groupings = @group.groupings
     @maps = @blog.maps
-    BlogsNoticeMailer.blogs_notice_mail.deliver
   end
 
   def new

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default 'Content-Transfer-Encoding' => '8bit'
+  # default 'Content-Transfer-Encoding' => '8bit'
   default from: 'daikons.msn36@gmail.com'
   layout 'mailer'
 end

--- a/app/mailers/blogs_notice_mailer.rb
+++ b/app/mailers/blogs_notice_mailer.rb
@@ -1,43 +1,9 @@
 class BlogsNoticeMailer < ApplicationMailer
-  before_action :email_sending_settings, only: %i[ blogs_notice_mail ]
-
   def blogs_notice_mail(group, blogs, blogs_month)
     @group = group
     @blogs = blogs
     @blogs_month = blogs_month
     # mail(to: @group.members.pluck(:email), subject: default_i18n_subject(group: @group.name))
     mail to: @group.members.pluck(:email), subject: "#{@group.name}の過去の#{@blogs_month}月のブログをお知らせします！"
-  end
-
-  private
-
-  # 月内の最終金曜日かを判断後、メールを送る内容を取得
-  def email_sending_settings
-    today = Date.today
-    one_week_later = today + 7
-    # return if today.mocn == one_week_later.mon
-    groups = Group.all
-    groups.each do |group|
-      case group.receiving_date 
-      when "one_month_ago"
-        blog_search_by_year_and_month(1, group, today)
-      when "two_months_ago"
-        blog_search_by_year_and_month(2, group, today)
-      when "three_months_ago"
-        blog_search_by_year_and_month(3, group, today)
-      end
-    end
-  end
-  
-  # blogsテーブルから数年分の指定月のレコードを取得するメソッド
-  def blog_search_by_year_and_month(how_many_months, group, today)
-    many_years_ago = today.year - group.delivery_start_year.year
-    months_by_year = []
-    for num in 1..many_years_ago do  
-      months_by_year << today.ago(num.years).since(how_many_months.month).all_month
-    end
-    blogs = group.blogs.where(email_notice: true, event_date: months_by_year).order(event_date: "DESC")
-    blogs_month = today.since(how_many_months.month).mon
-    blogs_notice_mail(group, blogs, blogs_month).deliver
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module ReTimeline
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
     config.load_defaults 6.0
+    config.paths.add 'lib', eager_load: true
 
     config.generators do |g|
       g.assets false

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,6 +30,8 @@ set :rbenv_type, :system
 # ただし挙動をしっかり確認したいのであれば :debug に設定する。
 set :log_level, :info
 
+set :whenever_roles, -> { :app }
+
 namespace :deploy do
   desc 'Restart application'
   task :restart do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,13 @@
+require File.expand_path(File.dirname(__FILE__) + "/environment")
+rails_env = ENV['RAILS_ENV'] || :development
+env :PATH, ENV['PATH']
+set :environment, rails_env
+set :output, "#{Rails.root}/log/cron.log"
+
 every :friday, at: '7pm' do
-  runner "BlogsNoticeMailer.blogs_notice_mail"
+  rake 'scheduled_delivery:email_scheduled_delivery'
+end
+
+every 1.minute do
+  rake 'scheduled_delivery:email_scheduled_delivery'
 end

--- a/lib/tasks/scheduled_delivery.rake
+++ b/lib/tasks/scheduled_delivery.rake
@@ -1,0 +1,32 @@
+namespace :scheduled_delivery do
+  desc '月の最終金曜日だった時、設定されている月の過去のグループブログ情報を取得し、メールを配信'
+  task email_scheduled_delivery: :environment do
+    # blogsテーブルから数年分の指定月のレコードを取得するメソッド
+    def blog_search_by_year_and_month(how_many_months, group, today)
+      many_years_ago = today.year - group.delivery_start_year.year
+      months_by_year = []
+      for num in 1..many_years_ago do  
+        months_by_year << today.ago(num.years).since(how_many_months.month).all_month
+      end
+      blogs = group.blogs.where(email_notice: true, event_date: months_by_year).order(event_date: "DESC")
+      blogs_month = today.since(how_many_months.month).mon
+      BlogsNoticeMailer.blogs_notice_mail(group, blogs, blogs_month).deliver
+    end
+
+    # 月内の最終金曜日かを判断後、メールを送る内容を取得
+    today = Date.today
+    one_week_later = today + 7
+    # exit if today.mon == one_week_later.mon
+    groups = Group.all
+    groups.each do |group|
+      case group.receiving_date 
+      when "one_month_ago"
+        blog_search_by_year_and_month(1, group, today)
+      when "two_months_ago"
+        blog_search_by_year_and_month(2, group, today)
+      when "three_months_ago"
+        blog_search_by_year_and_month(3, group, today)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Close #93 

## メール配信の不具合修正
mail_delivery_failure-issues#93

- [x] production.rbに`config.action_mailer.default_url_options = { host: "ec2-35-78-10-205.ap-northeast-1.compute.amazonaws.com"}`を追記し本番環境のurl関連のエラーを解消する
```
[52b2323a-a31b-421d-9a29-2c92032ada4e] ActionView::Template::Error (Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true):
[52b2323a-a31b-421d-9a29-2c92032ada4e]     1: <%= link_to t('blogs.blogs_notice.top_page_is_here_new_posts'), root_url %>
[52b2323a-a31b-421d-9a29-2c92032ada4e]     2: <h3><%= t 'blogs.blogs_notice.what_happened', month: @blogs_month %></h3>
[52b2323a-a31b-421d-9a29-2c92032ada4e]     3: <table>
[52b2323a-a31b-421d-9a29-2c92032ada4e]     4:   <tr>
```
- [x] rakeファイルを作成し不具合を修正
- [x] AWS上でwheneverが使えるようにする
- [x] 一次提出用にコードを修正
主にwhenever関連のコードを修正する

### 参考サイト
[RailsでMissing host to link to!が出たときに。model内でURL組み立てる場合の設定](https://qiita.com/daik/items/41a9bc8dec5ccec37f40)
[【Ruby on Rails】EC2でwheneverを使ってcrontabを設定する時のハマったことの解決](https://qiita.com/YutoYasunaga/items/16b3ee52f9db99ae75a1)
[returnでrake taskを終了しようとするとエラーが出る](https://spreadthec0ntents.com/entry/2021/04/26/rake_task%E3%82%92%E7%B5%82%E4%BA%86%E3%81%99%E3%82%8B%E6%99%82%E3%81%ABexit%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A6LocalJumpError%3A_unexpected_return%E3%82%92%E5%87%BA%E3%81%95%E3%81%AA)
[[Rails]Rails5 wheneverでRakeタスクを定期的に実行](https://zenn.dev/yusuke_docha/articles/2d2cfd1030f6ac)
[【Rails】wheneverを本番環境＋Capistranoで使う](https://qiita.com/kyoooko/items/27aa8e6c9809a387b66f)