### PR TITLE
【Fixed】mapsテーブルに情報が無い場合に編集時・確認画面で再入力が反映されるようにする

### DIFF
--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -5,5 +5,5 @@ class Blog < ApplicationRecord
   belongs_to :group
   mount_uploader :photo, PhotoUploader
   has_many :maps, dependent: :destroy
-  accepts_nested_attributes_for :maps, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :maps, allow_destroy: true
 end


### PR DESCRIPTION
Close #109 

## Google Maps情報が無い場合に編集時・確認画面で再入力が反映されるようにする
google_maps_bug_edit_and_check_resolution-issues#109

- [x] ブログの投稿確認、編集時にGoogle Mapsの情報が無い場合で、遷移・保存をした場合、地図情報の更新ができなくなる不具合を解決する。

Blog.rbに記載されている、
`accepts_nested_attributes_for :maps, allow_destroy: true, reject_if: :all_blank`
の`reject_if: :all_blank`を削除する。

`accepts_nested_attributes_for :maps, allow_destroy: true`とすればOK