### PR TITLE
【Fixed】ブログ投稿の際のバリデーション発生タイミングを変更

### DIFF
--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -27,9 +27,16 @@ class BlogsController < ApplicationController
   end
 
   def confirm
-    @blog = Blog.new(blog_params)
+    @blog = @group.blogs.build(blog_params)
+    @blog.new_contributor_id = current_user.id
     @maps = @blog.maps
     lat_log_present?
+    num = 0
+    @blog.maps.size.times do
+      @blog.maps[num][:group_id] = @group.id
+      num += 1
+    end
+    render :new if @blog.invalid?
   end
   
   def create
@@ -37,6 +44,11 @@ class BlogsController < ApplicationController
     lat_log_present?
     return render :new if params[:back]
     @blog.new_contributor_id = current_user.id
+    num = 0
+    @blog.maps.size.times do
+      @blog.maps[num][:group_id] = @group.id
+      num += 1
+    end
     if @blog.save
       redirect_to group_blogs_path(@group), notice: t('notice.blog_created', blog_title: @blog.title)
     else

--- a/app/views/blogs/confirm.html.erb
+++ b/app/views/blogs/confirm.html.erb
@@ -19,7 +19,6 @@
   <%= form.fields_for :maps do |map| %>
     <%= map.hidden_field :event_time %>
     <%= map.hidden_field :address %>
-    <%= map.hidden_field :group_id, value: @group.id %>
     <% @maps.each do |map| %>
       <p><%= t 'blogs.form.event_time' %>: <%= map.event_time.to_s(:time) if map.event_time.present? %></p>
       <p><%= t 'blogs.form.event_address' %>: <%= map.address %></p>


### PR DESCRIPTION
Close #115 

## ブログ投稿の際のバリデーション発生タイミングを変更
changed_timing_of_blog_post_validation_occurrence-issues#115

現状：ブログ投稿時にconfirm → createでバリデーションが発生するようになっている。
修正：ブログ投稿時にnew → confirmでバリデーションが発生するように変更する。