### PR TITLE
【Fixed】各ページでユーザー名・グループ名が出るように修正

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2 class="mb-5"><%= t('.edit_account_information') %></h2>
+<h2 class="mb-5"><%= t('users.show.user_name_edit_account_information', user_name: @user.name ) %></h2>
 
 <div class="form-size-ch text-left mx-auto mb-4">
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/diaries/confirm.html.erb
+++ b/app/views/diaries/confirm.html.erb
@@ -2,7 +2,7 @@
   data-turbolinks="false"
 <% end %>
 
-<h2 class="mb-5"><%= @group.name %><%= t '.is_the_diary_content_okay?' %></h2>
+<h2 class="mb-5"><%= t '.is_the_diary_content_okay?', group_name: @group.name %></h2>
 
 <%= form_with(model:[@group, @diary], local: true) do |form| %>
   <div class="text-left mb-4">

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -1,4 +1,4 @@
-<h1 class="mb-5"><%= @group.name %><%= t 'diaries.index.diary_editing' %></h1>
+<h1 class="mb-5"><%= t 'diaries.index.group_name_diary_editing', group_name: @group.name %></h1>
 
 <%= render 'form' %>
 

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="mb-5"><%= @group.name %><%= t '.diary_index' %></h1> 
+<h1 class="mb-5"><%= t '.group_name_diary_index', group_name: @group.name %></h1> 
 
 <div class="d-flex flex-row m-3">
   <div class="p-2" id="diary_new_link">

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="mb-5"><%= @group.name %><%= t 'diaries.index.new_diary_contribution' %></h1>
+<h1 class="mb-5"><%= t 'diaries.index.group_name_new_diary_contribution', group_name: @group.name %></h1>
 
 <%= render 'form' %>
 

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -2,7 +2,7 @@
   data-turbolinks="false"
 <% end %>
 
-<h1 class="mb-5"><%= @group.name %><%= t 'diaries.index.diary_detail' %></h1>
+<h1 class="mb-5"><%= t 'diaries.index.group_name_diary_detail', group_name: @group.name %></h1>
 
 <div class="text-left mb-4">
   <p>

--- a/app/views/diaries_notice_mailer/diaries_notice_mail.html.erb
+++ b/app/views/diaries_notice_mailer/diaries_notice_mail.html.erb
@@ -1,5 +1,5 @@
 <%= link_to t('diaries.diaries_notice.top_page_is_here_new_posts'), root_url %>
-<h3><%= t 'diaries.diaries_notice.what_happened', month: @diaries_month %></h3>
+<h3><%= t 'diaries.diaries_notice.what_happened', group_name: @group.name, month: @diaries_month %></h3>
 <table>
   <tr>
     <th><%= t 'diaries.index.title' %></th>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,4 +1,4 @@
-<h1 class="mb-5"><%= t 'groups.index.group_information_editing' %></h1>
+<h1 class="mb-5"><%= t 'groups.index.group_name_information_editing', group_name: @group.name %></h1>
 
 <%= render 'form' %>
 

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t '.list_of_affiliated_groups' %></h1><br>
+<h1><%= t '.user_name_list_of_affiliated_groups', user_name: current_user.name %></h1><br>
 
 <p class="text-left">
   <%= link_to t('.new_group_registration_here'), new_group_path, class: "btn btn-primary bi bi-plus-circle btn-lg m-2" %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -9,7 +9,7 @@
   </div>
 <% end %>
 
-<h1 class="mb-5"><%= t 'groups.index.group_information_details' %></h1>
+<h1 class="mb-5"><%= t 'groups.index.group_name_information_details', group_name: @group.name %></h1>
 
 <div class="d-flex flex-row">
   <div class="d-flex flex-column ">

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -2,7 +2,7 @@
   data-turbolinks="false"
 <% end %>
 
-<h2 class="mb-5"><%= @group.name %> <%= t 'diaries.index.event_location_map_index' %></h2>
+<h2 class="mb-5"><%= t 'diaries.index.event_location_map_index', group_name: @group.name %></h2>
 
 <div id='map' class="mx-auto container-fluid" style='height: 600px;'></div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t('.my_page', name: @user.name) %></h2>
+<h2><%= t('.my_page', user_name: @user.name) %></h2>
 <br>
 <div class="d-flex flex-row">
   <div class="d-flex flex-column ">

--- a/config/locales/views/diaries/ja.yml
+++ b/config/locales/views/diaries/ja.yml
@@ -2,6 +2,7 @@ ja:
   diaries:
     index:
       new_diary_contribution: '日記新規投稿'
+      group_name_new_diary_contribution: '『%{group_name}』日記新規投稿'
       new_diary_contribution_here: 'ここから日記の新規投稿ができます'
       title: 'タイトル'
       content: '内容'
@@ -11,8 +12,11 @@ ja:
       new_contributor: '新規投稿者'
       last_updater: '最終更新者'
       diary_index: '日記一覧'
+      group_name_diary_index: '『%{group_name}』日記一覧'
       diary_detail: '日記詳細'
+      group_name_diary_detail: '『%{group_name}』日記詳細'
       diary_editing: '日記編集'
+      group_name_diary_editing: '『%{group_name}』日記編集'
       diary_deletion: '日記削除'
       really_deleted?: '本当に削除しますか？'
       absence: '−'
@@ -28,7 +32,7 @@ ja:
       button_to_stop_an_email_notice_for_the_corresponding_diary: 'ボタンを押すと、該当する日記のメール通知を停止します。'
       button_to_initiate_an_email_notice_for_the_corresponding_diary: 'ボタンを押すと、該当する日記のメール通知を開始します。'
       refer_to_the_top_page_for_details_of_the_delivery_contents: '※配信内容の詳細については、トップページの「グループの日記をメールで自動配信」をご参照ください。'
-      event_location_map_index: 'イベント先地図一覧'
+      event_location_map_index: '『%{group_name}』イベント先地図一覧'
       do_you_want_to_set_up_with_this?: 'こちらで設定をしますか？'
     form:
       map_search: '地図検索'
@@ -39,10 +43,10 @@ ja:
       event_time: 'イベント時間'
       after_entering_the_event_destination_press_the_map_search_button: '※イベント先入力後は、地図検索ボタンを押してください'
     confirm:
-      is_the_diary_content_okay?: '日記を以下の内容で投稿して良いでしょうか？'
+      is_the_diary_content_okay?: '『%{group_name}』日記を以下の内容で投稿して良いでしょうか？'
       contribute: '投稿する'
       back: '戻る'
     diaries_notice:
       top_page_is_here_new_posts: 'Re: Timelineのトップページはこちらから！新しい思い出を記録しよう'
-      what_happened: '過去の%{month}月はこんな事があったよ！'
+      what_happened: '『%{group_name}』の過去の%{month}月はこんな事があったよ！'
 

--- a/config/locales/views/groups/ja.yml
+++ b/config/locales/views/groups/ja.yml
@@ -12,8 +12,11 @@ ja:
       group_name: 'グループ名'
       explanation: 'グループ説明'
       list_of_affiliated_groups: '所属グループ一覧'
+      user_name_list_of_affiliated_groups: '『%{user_name}』所属グループ一覧'
       group_information_details: 'グループ情報詳細'
+      group_name_information_details: '『%{group_name}』グループ情報詳細'
       group_information_editing: 'グループ情報編集'
+      group_name_information_editing: '『%{group_name}』グループ情報編集'
       group_deletion: 'グループ削除'
       group_diary_index: 'グループ日記一覧'
       really_deleted?: '本当に削除しますか？'
@@ -39,7 +42,7 @@ ja:
       press_the_button_to_cancel_group_admin_privileges: 'ボタンを押すと、グループ管理権限が解除されます。'
       press_the_button_to_grant_group_admin_privileges: 'ボタンを押すと、グループ管理権限が付与されます。'
     delivery_setup:
-      group_delivery_setup: "%{group_name}の配信設定"
+      group_delivery_setup: "『%{group_name}』の配信設定"
       setup: '設定'
       can_be_set_up_for_email_delivery: 'こちらからメール配信の設定ができます。'
       the_setting_results_are_displayed_below: '設定結果は下記に表示されます。'

--- a/config/locales/views/users/ja.yml
+++ b/config/locales/views/users/ja.yml
@@ -1,7 +1,8 @@
 ja:
   users:
     show:
-      my_page: '%{name}のマイページ'
+      my_page: '『%{user_name}』マイページ'
       name: '名前'
       email: 'メールアドレス'
       edit_account_information: 'アカウント情報編集'
+      user_name_edit_account_information: '『%{user_name}』アカウント情報編集'


### PR DESCRIPTION
Close #102 

display_of_user_and_group_names_on_each_page-issues#102

## 各ページでユーザー名・グループ名が出るようにする

- [x] グループ一覧でユーザー名が表示されるようにする
- [x] グループ詳細でグループ名が出るようにする
- [x] グループ編集でグループ名が出るようにする
- [x] 国際化の修正をする
- [x] マイページ修正
- [x] アカウント編集ページ修正
- [x] メール配信の本文にもグループ名を載せる

以上を行いました。