### PR TITLE
【Fixed】日記の写真を大きく表示できるようにする

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,3 +17,8 @@ import '../stylesheets/bootstrap-custom';
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
+
+window.addEventListener('popstate', function () {
+  window.location.reload();
+  console.log("Reload!");
+});

--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -7,7 +7,11 @@ class PhotoUploader < CarrierWave::Uploader::Base
   # storage :file
   storage :fog
 
-  process resize_to_limit: [50, 50]
+  # process resize_to_limit: [50, 50]
+
+  version :thumb do
+    process resize_to_limit: [50, 50]
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -73,7 +73,11 @@
         <% else %>
           <td class="align-middle"><%= t '.absence' %></td>
         <% end %>
-        <td class="align-middle"><%= image_tag diary.photo.url if diary.photo && diary.photo.url %>
+        <td class="align-middle">
+          <%= link_to diary.photo.url, "data-lightbox" => diary.photo.url do %>
+            <%= image_tag diary.photo.thumb.url if diary.photo && diary.photo.url %>
+          <% end %>
+        </td>
         <% if @group_admin %>
           <% if diary.email_notice %>
             <td class="align-middle">
@@ -100,3 +104,5 @@
     <% end %>
   </tbody>
 </table>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" type="text/javascript"></script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.0/font/bootstrap-icons.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet"> <%# Copyright (c) 2015 Lokesh Dhakar %>
   </head>
   
   <body>

--- a/config/locales/views/diaries/ja.yml
+++ b/config/locales/views/diaries/ja.yml
@@ -46,6 +46,8 @@ ja:
       is_the_diary_content_okay?: '『%{group_name}』日記を以下の内容で投稿して良いでしょうか？'
       contribute: '投稿する'
       back: '戻る'
+    show:
+      click_to_enlarge_photo: '※クリックすると写真が大きくなります'
     diaries_notice:
       top_page_is_here_new_posts: 'Re: Timelineのトップページはこちらから！新しい思い出を記録しよう'
       what_happened: '『%{group_name}』の過去の%{month}月はこんな事があったよ！'

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,6 +1,14 @@
 const webpack = require('webpack');
 const { environment } = require('@rails/webpacker')
 
-environment.plugins.append('ProvidePlugin-jQuery', new webpack.ProvidePlugin({jQuery: 'jquery'}));
+// environment.plugins.append('ProvidePlugin-jQuery', new webpack.ProvidePlugin({jQuery: 'jquery'}));
+
+environment.plugins.prepend('Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery',
+        Popper: 'popper.js'
+    })
+)
 
 module.exports = environment


### PR DESCRIPTION
Close #125 

enlarge_the_diary_photo-issues#125

## 日記の写真を大きく表示できるようにする（タスク）
- [x] Lightbox2による実装
- [x] 日記、確認画面・一覧画面・編集画面・詳細画面での写真サイズの扱いを考える
- [x] 日記、一覧画面でLightbox2のリンクが切れてしまう原因を探る

## 日記、一覧画面でLightbox2のリンクが切れてしまう原因を探る
### 問題
http://localhost:3000/groups → http://localhost:3000/groups/1/diariesとした場合、Lightbox2のリンクが切れてしまう。

### 対応
head内に`<script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" type="text/javascript"></script>`を記述するとうまく動かないので、bodyの中に記述。
↓
その代わりにブラウザの戻るボタンで戻ると、"くるくる回る"ようになってしまう。
↓
 `application.js`または`diaries/index.html.erb`に下記のコードを記入する⤵︎
```
window.addEventListener('popstate', function (e) {
    window.location.reload();
    console.log("Reload!");
});
```
を記述し解決、ブラウザの「進む」「戻る」で遷移をした場合のみ、リロードを行うようにした。

### Lightbox2参考サイト
[画像を拡大してポップアップ表示できる”Lightbox2″の使い方](https://web-saku.net/javascript-lightbox2/)
[画像拡大スクリプトLightbox2の簡単な設置方法&使い方](https://allabout.co.jp/gm/gc/470618/#aa470618-Lightbox-Use)
[carrierwave](https://github.com/carrierwaveuploader/carrierwave)

### ブラウザでの「進む」「戻る」時にjavascriptが不具合を起こす参考サイト
[historyback（ブラウザの戻るボタン）時のjsによる再読み込み](https://www.sejuku.net/plus/question/detail/90)

以上が完了しました。