### PR TITLE
【Fixed】グループ管理者のみ配信設定ができるように実装

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -49,6 +49,8 @@ class GroupsController < ApplicationController
   end
 
   def delivery_setup
+    redirect_to group_diaries_path(@group) unless group_admin?
+
     today = Date.today
     @last_year = today.year - 1
     @one_hundred_years_ago = today.prev_year(100).year

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -5,9 +5,11 @@
     <%= link_to t('.new_diary_contribution_here'), new_group_diary_path(@group), data: {"turbolinks"=>false}, class: "btn btn-primary btn-lg bi bi-pencil-fill" %>
   </div>
 
-  <div class="p-2">
-    <%= link_to t('.diary_delivery_setting_here'), delivery_setup_group_path(@group), class: "btn btn-secondary btn-lg bi bi-stopwatch-fill" %>
-  </div>
+  <% if @group_admin %>
+    <div class="p-2">
+      <%= link_to t('.diary_delivery_setting_here'), delivery_setup_group_path(@group), class: "btn btn-secondary btn-lg bi bi-stopwatch-fill" %>
+    </div>
+  <% end %>
 
   <div class="p-2">
     <%= link_to t('.the_event_address_here'), group_maps_path(@group), data: {"turbolinks"=>false}, class: "btn btn-info btn-lg bi bi-map-fill" %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -3,7 +3,7 @@
 <p class="text-left">
   <%= link_to t('.new_group_registration_here'), new_group_path, class: "btn btn-primary bi bi-plus-circle btn-lg m-2" %>
 </p>
-
+  
 <p class="text-left">
   <%= t '.to_add_members_to_a_group_click_on_the_appropriate_group_name' %>
 </p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,9 +27,11 @@
           <div class="p-3">
             <%= link_to t('diaries.index.diary_index'), group_diaries_path(@group), class: "bi bi-clipboard-data" %>
           </div>
-          <div class="p-3">
-            <%= link_to t('diaries.index.delivery_setup'),  delivery_setup_group_path(@group), class: "bi bi-stopwatch-fill" %>
-          </div>
+          <% if @group_admin %>
+            <div class="p-3">
+              <%= link_to t('diaries.index.delivery_setup'),  delivery_setup_group_path(@group), class: "bi bi-stopwatch-fill" %>
+            </div>
+          <% end %>
         <% elsif controller_name == "groups" %>
           <div  class="p-3">
             <%= link_to t('groups.index.group_new_registration'), new_group_path, class: "bi bi-plus-circle" %>


### PR DESCRIPTION
Close #145 

only_the_group_admin_can_set_up_distribution-issues#145

- [x] グループ管理者以外は配信設定画面に遷移できないようにする
- [x] グループ管理者以外は「header」「日記一覧」に「配信設定のリンク」が表示されないようにする

以上が完了しました。