### PR TITLE
【Fixed】アカウント編集の不具合解消

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,5 +9,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 end


### PR DESCRIPTION
Close #148 

account_editing_bug_resolved-issues#148

- [x] アカウント編集時にnameが変更できない不具合を修正する

application_controller.rbに下記を追加
```
devise_parameter_sanitizer.permit(:account_update, keys: [:name])
```